### PR TITLE
Every release should auto-commit next snapshot version

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Release artifacts
+cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy
+
+# Update version by 1
+newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
+
+# Replace first occurrence of TRAVIS_TAG with newVersion appended with SNAPSHOT 
+sed -i "0,/<version>$TRAVIS_TAG/s//<version>$newVersion-SNAPSHOT/" pom.xml
+
+git commit pom.xml -m "Upgrade version to $newVersion-SNAPSHOT" --author "Github Bot <githubbot@gluonhq.com>"
+git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-maven-plugin

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,16 @@ cache:
     - $HOME/.gradle/caches/
 
 deploy:
-  # Deploy snapshots & releases on every commit made to master
+  # Deploy snapshots on every commit made to master
   - provider: script
     script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
     skip_cleanup: true
     on:
-      all_branches: true
+      branch: master
+
+  # Deploy releases on every tag push
+  - provider: script
+    script: sh .ci/release.sh
+    skip_cleanup: true
+    on:
+      tags: true


### PR DESCRIPTION
Given tag version is equal to the version specified in the pom.xml file, this change will update the version x.x.x to x.x.x+1 and append SNAPSHOT to it. This file will then be committed back to the repository.

All commits will be done by Github user - Gluon Bot.

An environment variable GITHUB_PASSWORD needs to be added to TRAVIS.