### PR TITLE
Auto-commit for next snapshot version should be on master branch

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -10,4 +10,4 @@ newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
 sed -i "0,/<version>$TRAVIS_TAG/s//<version>$newVersion-SNAPSHOT/" pom.xml
 
 git commit pom.xml -m "Upgrade version to $newVersion-SNAPSHOT" --author "Github Bot <githubbot@gluonhq.com>"
-git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-maven-plugin
+git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-maven-plugin HEAD:master


### PR DESCRIPTION
Since the release build by Travis is done on the tag and not on a branch, we need to explicitly define the branch for the push.