### PR TITLE
Update plugin to work with Gluon Substrate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <groupId>com.gluonhq</groupId>
   <artifactId>client-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.0.13</version>
+  <version>0.0.14-SNAPSHOT</version>
   <name>client-maven-plugin Maven Mojo</name>
   <description>The Gluon Client Plugin is used to run JavaFX 11+ projects with Graal</description>
   <inceptionYear>2019</inceptionYear>
@@ -53,8 +53,8 @@
   <dependencies>
     <dependency>
       <groupId>com.gluonhq</groupId>
-      <artifactId>omega</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <artifactId>substrate</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -123,6 +123,10 @@
     <repository>
       <id>gluon-releases</id>
       <url>https://nexus.gluonhq.com/nexus/content/repositories/releases</url>
+    </repository>
+    <repository>
+        <id>snapshot</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
   </repositories>
 

--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -74,10 +74,10 @@ public abstract class NativeBaseMojo extends AbstractMojo {
     @Parameter(property = "client.llcPath")
     String llcPath;
 
-    @Parameter(property = "client.javaStaticSdkVersion", defaultValue = "11-ea+8")
+    @Parameter(property = "client.javaStaticSdkVersion", defaultValue = "14-ea+2")
     String javaStaticSdkVersion;
 
-    @Parameter(property = "client.javafxStaticSdkVersion", defaultValue = "13-ea+7")
+    @Parameter(property = "client.javafxStaticSdkVersion", defaultValue = "14-ea+gvm1")
     String javafxStaticSdkVersion;
 
     @Parameter(property = "client.target", defaultValue = "host")

--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -154,9 +154,9 @@ public abstract class NativeBaseMojo extends AbstractMojo {
         String osname = System.getProperty("os.name", "Mac OS X").toLowerCase(Locale.ROOT);
         Triplet hostTriplet;
         if (osname.contains("mac")) {
-            hostTriplet = new Triplet(Constants.ARCH_AMD64, Constants.VENDOR_APPLE, Constants.OS_DARWIN);
+            hostTriplet = new Triplet(Constants.Profile.MACOS);
         } else if (osname.contains("nux")) {
-            hostTriplet = new Triplet(Constants.ARCH_AMD64, Constants.VENDOR_LINUX, Constants.OS_LINUX);
+            hostTriplet = new Triplet(Constants.Profile.LINUX);
         } else {
             throw new RuntimeException("OS " + osname + " not supported");
         }
@@ -168,10 +168,10 @@ public abstract class NativeBaseMojo extends AbstractMojo {
                 targetTriplet = hostTriplet;
                 break;
             case Constants.TARGET_IOS:
-                targetTriplet = new Triplet(Constants.ARCH_AMD64, Constants.VENDOR_APPLE, Constants.OS_DARWIN);
+                targetTriplet = new Triplet(Constants.Profile.IOS);
                 break;
             case Constants.TARGET_IOS_SIM:
-                targetTriplet = new Triplet(Constants.ARCH_AMD64, Constants.VENDOR_APPLE, Constants.TARGET_IOS);
+                targetTriplet = new Triplet(Constants.Profile.IOS_SIM);
                 break;
             default:
                 throw new RuntimeException("No valid target found for " + target);

--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -160,7 +160,6 @@ public abstract class NativeBaseMojo extends AbstractMojo {
         } else {
             throw new RuntimeException("OS " + osname + " not supported");
         }
-        clientConfig.setHostTriplet(hostTriplet);
 
         Triplet targetTriplet = null;
         switch (target) {

--- a/src/main/java/com/gluonhq/NativeCompileMojo.java
+++ b/src/main/java/com/gluonhq/NativeCompileMojo.java
@@ -30,7 +30,7 @@
 
 package com.gluonhq;
 
-import com.gluonhq.omega.Omega;
+import com.gluonhq.substrate.SubstrateDispatcher;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -38,6 +38,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -74,7 +75,7 @@ public class NativeCompileMojo extends NativeBaseMojo {
         getLog().debug("cp = " + cp);
 
         try {
-            Omega.nativeCompile(buildRoot, clientConfig, cp);
+            SubstrateDispatcher.nativeCompile(Paths.get(buildRoot), clientConfig, cp);
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);

--- a/src/main/java/com/gluonhq/NativeLinkMojo.java
+++ b/src/main/java/com/gluonhq/NativeLinkMojo.java
@@ -35,7 +35,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
-import java.io.File;
 import java.nio.file.Path;
 
 
@@ -47,11 +46,11 @@ public class NativeLinkMojo extends NativeBaseMojo {
         super.execute();
 
         try {
-            File client = outputDir.toPath().toFile();
-            Path tmpPath = client.toPath().resolve("gvm").resolve("tmp");
+            Path client = outputDir.toPath();
+            Path tmpPath = client.resolve("gvm").resolve("tmp");
             getLog().debug("Start linking in " + tmpPath.toString());
 
-            SubstrateDispatcher.nativeLink(client.toPath(), clientConfig);
+            SubstrateDispatcher.nativeLink(client, clientConfig);
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);

--- a/src/main/java/com/gluonhq/NativeLinkMojo.java
+++ b/src/main/java/com/gluonhq/NativeLinkMojo.java
@@ -29,7 +29,7 @@
  */
 package com.gluonhq;
 
-import com.gluonhq.omega.Omega;
+import com.gluonhq.substrate.SubstrateDispatcher;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -51,7 +51,7 @@ public class NativeLinkMojo extends NativeBaseMojo {
             Path tmpPath = client.toPath().resolve("gvm").resolve("tmp");
             getLog().debug("Start linking in " + tmpPath.toString());
 
-            Omega.nativeLink(client.getAbsolutePath(), clientConfig);
+            SubstrateDispatcher.nativeLink(client.toPath(), clientConfig);
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);

--- a/src/main/java/com/gluonhq/NativeRunMojo.java
+++ b/src/main/java/com/gluonhq/NativeRunMojo.java
@@ -30,7 +30,7 @@
 
 package com.gluonhq;
 
-import com.gluonhq.omega.Omega;
+import com.gluonhq.substrate.SubstrateDispatcher;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 
@@ -46,7 +46,7 @@ public class NativeRunMojo extends NativeBaseMojo {
             Path client = outputDir.toPath();
             getLog().debug("Start running in " + client.toString());
 
-            Omega.nativeRun(client.toString(), clientConfig);
+            SubstrateDispatcher.nativeRun(client, clientConfig);
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);

--- a/src/main/java/com/gluonhq/attach/AttachArtifactResolver.java
+++ b/src/main/java/com/gluonhq/attach/AttachArtifactResolver.java
@@ -30,7 +30,7 @@
 
 package com.gluonhq.attach;
 
-import com.gluonhq.omega.attach.AttachResolver;
+import com.gluonhq.substrate.attach.AttachResolver;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Repository;

--- a/src/main/java/com/gluonhq/attach/AttachServiceDefinition.java
+++ b/src/main/java/com/gluonhq/attach/AttachServiceDefinition.java
@@ -30,8 +30,8 @@
 
 package com.gluonhq.attach;
 
-import com.gluonhq.omega.attach.AttachService;
-import com.gluonhq.omega.util.Constants;
+import com.gluonhq.substrate.Constants;
+import com.gluonhq.substrate.attach.AttachService;
 
 import java.util.Locale;
 import java.util.stream.Collectors;


### PR DESCRIPTION
Contains changes to use Gluon Substrate instead of Gluon Omega. 

For now, the plugin depends on `substrate-0.0.1-SNAPSHOT`.