### PR TITLE
Use maven commands to update project and substrate versions

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -6,8 +6,11 @@ cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy
 # Update version by 1
 newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
 
-# Replace first occurrence of TRAVIS_TAG with newVersion appended with SNAPSHOT 
-sed -i "0,/<version>$TRAVIS_TAG/s//<version>$newVersion-SNAPSHOT/" pom.xml
+# Update project version to next snapshot version
+mvn versions:set -DnewVersion=$newVersion-SNAPSHOT -DgenerateBackupPoms=false
 
-git commit pom.xml -m "Upgrade version to $newVersion-SNAPSHOT" --author "Github Bot <githubbot@gluonhq.com>"
+# Update Substrate to next snapshot version
+mvn versions:use-next-snapshots -Dincludes=com.gluonhq:substrate -DgenerateBackupPoms=false
+
+git commit pom.xml -m "Prepare development of $newVersion" --author "Gluon Bot <githubbot@gluonhq.com>"
 git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-maven-plugin HEAD:master


### PR DESCRIPTION
Once we release the plugin version, there a manual process to update Substrate to the next snapshot version. 

This PR automates the process, given the next snapshot version is already released in a snapshot repository.