### PR TITLE
Don't simply return true when linking failed

### DIFF
--- a/src/main/java/com/gluonhq/NativeLinkMojo.java
+++ b/src/main/java/com/gluonhq/NativeLinkMojo.java
@@ -51,7 +51,8 @@ public class NativeLinkMojo extends NativeBaseMojo {
             getLog().debug("Start linking in " + tmpPath.toString());
 
             SubstrateDispatcher dispatcher = new SubstrateDispatcher(client, clientConfig);
-            dispatcher.nativeLink(getProjectClasspath());
+            boolean result = dispatcher.nativeLink(getProjectClasspath());
+            if (!result) throw new RuntimeException("Linking failed");
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);


### PR DESCRIPTION
This fixes #67 
It also addresses https://github.com/gluonhq/substrate/issues/168 (without fixing the root cause)