### PR TITLE
Update plugin version in client-samples after release

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -13,4 +13,7 @@ mvn versions:set -DnewVersion=$newVersion-SNAPSHOT -DgenerateBackupPoms=false
 mvn versions:use-next-snapshots -Dincludes=com.gluonhq:substrate -DgenerateBackupPoms=false
 
 git commit pom.xml -m "Prepare development of $newVersion" --author "Gluon Bot <githubbot@gluonhq.com>"
-git push https://gluon-bot:$GITHUB_PASSWORD@github.com/gluonhq/client-maven-plugin HEAD:master
+git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$TRAVIS_REPO_SLUG HEAD:master
+
+# Update samples
+sh update-samples.sh "$newVersion"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -16,4 +16,4 @@ git commit pom.xml -m "Prepare development of $newVersion" --author "Gluon Bot <
 git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$TRAVIS_REPO_SLUG HEAD:master
 
 # Update samples
-sh update-samples.sh "$newVersion"
+sh .ci/update-samples.sh "$newVersion"

--- a/.ci/update-samples.sh
+++ b/.ci/update-samples.sh
@@ -1,0 +1,14 @@
+export SAMPLES_REPO_SLUG=gluonhq/client-samples
+
+cd $TRAVIS_BUILD_DIR
+git clone https://github.com/$SAMPLES_REPO_SLUG
+cd client-samples/Maven
+
+# Update plugin version
+mvn -f HelloFX versions:set-property -Dproperty=client.plugin.version -DnewVersion="$1" -DgenerateBackupPoms=false
+mvn -f HelloFXML versions:set-property -Dproperty=client.plugin.version -DnewVersion="$1" -DgenerateBackupPoms=false
+mvn -f HelloGluon versions:set-property -Dproperty=client.plugin.version -DnewVersion="$1" -DgenerateBackupPoms=false
+mvn -f HelloWorld versions:set-property -Dproperty=client.plugin.version -DnewVersion="$1" -DgenerateBackupPoms=false
+
+git commit */pom.xml -m "Upgrade client-maven-plugin version to $newVersion" --author "Gluon Bot <githubbot@gluonhq.com>"
+git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$SAMPLES_REPO_SLUG HEAD:master


### PR DESCRIPTION
PR automates the job of updating `client-maven-plugin` version in all the projects inside [client-samples](https://github.com/gluonhq/client-samples).

This PR has a dependency on https://github.com/gluonhq/client-samples/pull/34.