### PR TITLE
Fix variable name containing the new version

### DIFF
--- a/.ci/update-samples.sh
+++ b/.ci/update-samples.sh
@@ -10,5 +10,5 @@ mvn -f HelloFXML versions:set-property -Dproperty=client.plugin.version -DnewVer
 mvn -f HelloGluon versions:set-property -Dproperty=client.plugin.version -DnewVersion="$1" -DgenerateBackupPoms=false
 mvn -f HelloWorld versions:set-property -Dproperty=client.plugin.version -DnewVersion="$1" -DgenerateBackupPoms=false
 
-git commit */pom.xml -m "Upgrade client-maven-plugin version to $newVersion" --author "Gluon Bot <githubbot@gluonhq.com>"
+git commit */pom.xml -m "Upgrade client-maven-plugin version to $1" --author "Gluon Bot <githubbot@gluonhq.com>"
 git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$SAMPLES_REPO_SLUG HEAD:master


### PR DESCRIPTION
This fixes a mistake made in https://github.com/gluonhq/client-maven-plugin/pull/70