### PR TITLE
Substrate dependency should be update to the release version

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Update substrate to release version
+mvn versions:use-releases -Dincludes=com.gluonhq:substrate -DgenerateBackupPoms=false
+
 # Release artifacts
 cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy
 


### PR DESCRIPTION
This PR makes sure that before we release the plugin, we use the release version of substrate i.e. remove  `-SNAPSHOT`, if exists.