### PR TITLE
Updates to release process

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -7,11 +7,6 @@ set -e
 git config --global user.name "Gluon Bot"
 git config --global user.email "githubbot@gluonhq.com"
 
-# Update substrate to release version
-mvn versions:use-releases -Dincludes=com.gluonhq:substrate -DgenerateBackupPoms=false
-substrateReleaseVersion=$(xmlstarlet sel -t -v "//_:dependency[_:artifactId='substrate']/_:version" pom.xml)
-git commit pom.xml -m "Update Substrate version to $substrateReleaseVersion"
-
 # Release artifacts
 cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
- ~ Copyright (c) 2019, Gluon
+ ~ Copyright (c) 2019, 2020, Gluon
  ~ All rights reserved.
  ~
  ~ Redistribution and use in source and binary forms, with or without
@@ -125,8 +125,8 @@
       <url>https://nexus.gluonhq.com/nexus/content/repositories/releases</url>
     </repository>
     <repository>
-        <id>snapshot</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>snapshot</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
     </repository>
   </repositories>
 
@@ -145,6 +145,29 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
         <version>3.6.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <id>enforce-no-snapshots</id>
+            <phase>install</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireReleaseDeps>
+                  <message>Snapshot dependencies are not allowed for release project version!</message>
+                  <onlyWhenRelease>true</onlyWhenRelease> 
+                </requireReleaseDeps>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
1. We do not want to silently update substrate snapshot version to release version and then commit it as a part of release pipeline. This leads to a discrepancy when a release is made with `pom.xml` containing a SNAPSHOT version of Substrate. In this particular case, when the artifact is released to Nexus, the `pom.xml` in Nexus has the correct version of Substrate (as the release script updated SNAPSHOT to release version). However, the release tag still points a commit with pom.xml containing the SNAPSHOT version.
2. Use the maven-enforcer-plugin to check for snapshot dependencies. We do not want any snapshot dependency to be a part of release
3. maven-enforcer-plugin is active only when the deploy is called for a release version (and inactive for snapshot releases)