### PR TITLE
Add support for configuring custom Attach services

### DIFF
--- a/src/main/java/com/gluonhq/attach/AttachService.java
+++ b/src/main/java/com/gluonhq/attach/AttachService.java
@@ -1,95 +1,83 @@
-/*
- * Copyright (c) 2019, Gluon
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.gluonhq.attach;
 
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 
-/**
- * List of all available services in Attach
- * See https://github.com/gluonhq/attach
- *
- * Each service has an iOS implementation, and some of them
- * a desktop implementation as well
- */
-public enum AttachService {
-    ACCELEROMETER,
-    AUDIO_RECORDING(true /* desktopSupported */),
-    AUGMENTED_REALITY,
-    BARCODE_SCAN,
-    BATTERY,
-    BLE,
-    BROWSER,
-    CACHE(true /* desktopSupported */),
-    COMPASS,
-    CONNECTIVITY,
-    DEVICE,
-    DIALER,
-    DISPLAY(true /* desktopSupported */),
-    IN_APP_BILLING,
-    LIFECYCLE(true /* desktopSupported */),
-    LOCAL_NOTIFICATIONS,
-    MAGNETOMETER,
-    ORIENTATION,
-    PICTURES,
-    POSITION,
-    PUSH_NOTIFICATIONS,
-    RUNTIME_ARGS(true /* desktopSupported */),
-    SETTINGS(true /* desktopSupported */),
-    SHARE,
-    STATUSBAR,
-    STORAGE(true /* desktopSupported */),
-    VIBRATION,
-    VIDEO;
+public class AttachService {
 
-    private boolean androidSupported = true;
-    private boolean iosSupported = true;
-    private boolean desktopSupported = false;
+    public static final List<AttachService> GLUON_ATTACH_MODULES = new LinkedList<>();
 
-    AttachService() { }
+    private static final String DEPENDENCY_GROUP = "com.gluonhq.attach";
 
-    AttachService(boolean desktopSupported) {
-        this.desktopSupported = desktopSupported;
+    static {
+        for (GluonAttachServices gluonAttachService : GluonAttachServices.values()) {
+            String artifactId = gluonAttachService.getServiceName();
+
+            GLUON_ATTACH_MODULES.add(
+                    new AttachService(
+                            DEPENDENCY_GROUP,
+                            artifactId,
+                            gluonAttachService.isAndroidSupported(),
+                            gluonAttachService.isIosSupported(),
+                            gluonAttachService.isDesktopSupported()));
+        }
+    }
+
+    @Parameter(required = true)
+    private String groupId;
+
+    @Parameter(required = true)
+    private String artifactId;
+
+    @Parameter
+    private boolean androidSupport = true;
+
+    @Parameter
+    private boolean iosSupport = true;
+
+    @Parameter
+    private boolean desktopSupport = false;
+
+    public AttachService() {}
+
+    public AttachService(
+            String groupId,
+            String artifactId,
+            boolean androidSupport,
+            boolean iosSupport,
+            boolean desktopSupport) {
+
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.androidSupport = androidSupport;
+        this.iosSupport = iosSupport;
+        this.desktopSupport = desktopSupport;
     }
 
     public String getServiceName() {
-        return name().replace('_', '-').toLowerCase(Locale.ROOT);
+        return artifactId.replace('_', '-').toLowerCase(Locale.ROOT);
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
     }
 
     public boolean isAndroidSupported() {
-        return androidSupported;
+        return androidSupport;
     }
 
     public boolean isIosSupported() {
-        return iosSupported;
+        return iosSupport;
     }
 
     public boolean isDesktopSupported() {
-        return desktopSupported;
+        return desktopSupport;
     }
 }
-

--- a/src/main/java/com/gluonhq/attach/AttachServiceDefinition.java
+++ b/src/main/java/com/gluonhq/attach/AttachServiceDefinition.java
@@ -32,42 +32,25 @@ package com.gluonhq.attach;
 
 import com.gluonhq.substrate.Constants;
 
-import java.util.Locale;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 public class AttachServiceDefinition {
 
-    private String name;
-    private AttachService service;
+    private final AttachService service;
 
-    AttachServiceDefinition(String name) {
-        this.name = name;
-
-        try {
-            this.service = AttachService.valueOf(name.replace('-', '_').toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            String services = Stream.of(AttachService.values())
-                    .map(AttachService::getServiceName)
-                    .collect(Collectors.joining(", "));
-            throw new RuntimeException("Invalid name for Attach service: " + name +
-                    " from list of services: " + services, e);
-        }
-    }
-
-    AttachService getService() {
-        return service;
+    AttachServiceDefinition(AttachService attachService) {
+        this.service = attachService;
     }
 
     String getSupportedPlatform(String target) {
         switch (target) {
             case Constants.TARGET_HOST:
-                return getService().isDesktopSupported() ? "desktop" : "";
+                return service.isDesktopSupported() ? "desktop" : "";
+
             case Constants.TARGET_IOS:
             case Constants.TARGET_IOS_SIM:
-                return getService().isIosSupported() ? "ios" : "";
+                return service.isIosSupported() ? "ios" : "";
+
             case Constants.PROFILE_ANDROID:
-                return getService().isAndroidSupported() ? "android" : "";
+                return service.isAndroidSupported() ? "android" : "";
             default:
                 throw new RuntimeException("No valid target found for " + target);
         }
@@ -80,13 +63,11 @@ public class AttachServiceDefinition {
 
         AttachServiceDefinition that = (AttachServiceDefinition) o;
 
-        return name.equals(that.name);
-
+        return service.getServiceName().equals(that.service.getServiceName());
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return service.getServiceName().hashCode();
     }
-
 }

--- a/src/main/java/com/gluonhq/attach/GluonAttachServices.java
+++ b/src/main/java/com/gluonhq/attach/GluonAttachServices.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.attach;
+
+import java.util.Locale;
+
+/**
+ * List of all available services in Attach
+ * See https://github.com/gluonhq/attach
+ *
+ * Each service has an iOS implementation, and some of them
+ * a desktop implementation as well
+ */
+public enum GluonAttachServices {
+    ACCELEROMETER,
+    AUDIO_RECORDING(true /* desktopSupported */),
+    AUGMENTED_REALITY,
+    BARCODE_SCAN,
+    BATTERY,
+    BLE,
+    BROWSER,
+    CACHE(true /* desktopSupported */),
+    COMPASS,
+    CONNECTIVITY,
+    DEVICE,
+    DIALER,
+    DISPLAY(true /* desktopSupported */),
+    FIREBASE,
+    IN_APP_BILLING,
+    LIFECYCLE(true /* desktopSupported */),
+    LOCAL_NOTIFICATIONS,
+    MAGNETOMETER,
+    ORIENTATION,
+    PICTURES,
+    POSITION,
+    PUSH_NOTIFICATIONS,
+    RUNTIME_ARGS(true /* desktopSupported */),
+    SETTINGS(true /* desktopSupported */),
+    SHARE,
+    STATUSBAR,
+    STORAGE(true /* desktopSupported */),
+    VIBRATION,
+    VIDEO;
+
+    private boolean androidSupported = true;
+    private boolean iosSupported = true;
+    private boolean desktopSupported = false;
+
+    GluonAttachServices() { }
+
+    GluonAttachServices(boolean desktopSupported) {
+        this.desktopSupported = desktopSupported;
+    }
+
+    public String getServiceName() {
+        return name().replace('_', '-').toLowerCase(Locale.ROOT);
+    }
+
+    public boolean isAndroidSupported() {
+        return androidSupported;
+    }
+
+    public boolean isIosSupported() {
+        return iosSupported;
+    }
+
+    public boolean isDesktopSupported() {
+        return desktopSupported;
+    }
+}
+


### PR DESCRIPTION
This PR adds support for including dependencies outside of the `com.gluonhq.attach` group identifier in the Attach service resolution logic.

Here's an example:

```xml
<plugin>
    <groupId>com.gluonhq</groupId>
    <artifactId>client-maven-plugin</artifactId>
    <version>${client.plugin.version}</version>
    <configuration>
        <target>ios</target>
        <verbose>true</verbose>

        <attachServices>
            <attachService>
                <groupId>com.stevesoltys.myproject</groupId>
                <artifactId>my-custom-attach-module</artifactId>
            </attachService>
        </attachServices>

        <attachList>
            <list>display</list>
            <list>lifecycle</list>
            <list>statusbar</list>
            <list>storage</list>
            <list>cache</list>
            <list>my-custom-attach-module</list>
        </attachList>

        <mainClass>${mainClassName}</mainClass>
    </configuration>
</plugin>
```

I'm not sure if this is something that you'd like to include in the project, but I found it to be very useful so I figured I'd see if you'd like it upstreamed.