### PR TITLE
Add support for configurable per-target link flags

### DIFF
--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -31,6 +31,7 @@
 package com.gluonhq;
 
 import com.gluonhq.attach.AttachArtifactResolver;
+import com.gluonhq.parameter.TargetLinkFlagParameter;
 import com.gluonhq.substrate.Constants;
 import com.gluonhq.substrate.ProjectConfiguration;
 import com.gluonhq.substrate.model.IosSigningConfiguration;
@@ -99,6 +100,9 @@ public abstract class NativeBaseMojo extends AbstractMojo {
 
     @Parameter(property = "client.nativeImageArgs")
     List<String> nativeImageArgs;
+
+    @Parameter(property = "client.linkFlags")
+    Map<String, TargetLinkFlagParameter> linkFlags;
 
     @Parameter(readonly = true, required = true, defaultValue = "${project.build.directory}/client")
     File outputDir;
@@ -177,6 +181,13 @@ public abstract class NativeBaseMojo extends AbstractMojo {
         clientConfig.setResourcesList(resourcesList);
         clientConfig.setJniList(jniList);
         clientConfig.setCompilerArgs(nativeImageArgs);
+
+        clientConfig.setLinkFlags(linkFlags.keySet().stream()
+                .collect(Collectors.toMap(
+                        key -> key,
+                        key -> linkFlags.get(key).getFlags()
+                )));
+
         clientConfig.setReflectionList(reflectionList);
         clientConfig.setAppId(project.getGroupId() + "." + project.getArtifactId());
         clientConfig.setAppName(project.getName());

--- a/src/main/java/com/gluonhq/parameter/TargetLinkFlagParameter.java
+++ b/src/main/java/com/gluonhq/parameter/TargetLinkFlagParameter.java
@@ -1,0 +1,15 @@
+package com.gluonhq.parameter;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.List;
+
+public class TargetLinkFlagParameter {
+
+    @Parameter
+    private List<String> flags;
+
+    public List<String> getFlags() {
+        return flags;
+    }
+}


### PR DESCRIPTION
Dependent on https://github.com/gluonhq/substrate/pull/414.

This adds support for providing additional linker flags on a per-target basis. An example use case for this is linking with additional frameworks during iOS builds.

Here's an example:

```xml
<plugin>
    <groupId>com.gluonhq</groupId>
    <artifactId>client-maven-plugin</artifactId>
    <version>${client.plugin.version}</version>
    <configuration>
        <target>ios</target>
        <verbose>true</verbose>

        <attachServices>
            <attachService>
                <groupId>com.stevesoltys.myproject</groupId>
                <artifactId>google-sign-in</artifactId>
            </attachService>
        </attachServices>

        <linkFlags>
            <ios>
                <flags>
                    <list>-Wl,-framework,LocalAuthentication</list>
                    <list>-Wl,-framework,SafariServices</list>
                    <list>-Wl,-framework,AuthenticationServices</list>
                    <list>-Wl,-framework,SystemConfiguration</list>
                    <list>-Wl,-framework,AppAuth</list>
                    <list>-Wl,-framework,GoogleSignIn</list>
                    <list>-Wl,-framework,GTMAppAuth</list>
                    <list>-Wl,-framework,GTMSessionFetcher</list>
                    <list>-ObjC</list>
                </flags>
            </ios>
        </linkFlags>

        <attachList>
            <list>display</list>
            <list>lifecycle</list>
            <list>statusbar</list>
            <list>storage</list>
            <list>cache</list>
            <list>google-sign-in</list>
        </attachList>

        <mainClass>${mainClassName}</mainClass>

    </configuration>
</plugin>
```