### PR TITLE
package and install goals fail when substrate call fails

### DIFF
--- a/src/main/java/com/gluonhq/NativeInstallMojo.java
+++ b/src/main/java/com/gluonhq/NativeInstallMojo.java
@@ -40,13 +40,17 @@ public class NativeInstallMojo extends NativeBaseMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        boolean result = true;
         try {
             SubstrateDispatcher dispatcher = createSubstrateDispatcher();
-            dispatcher.nativeInstall();
+            result = dispatcher.nativeInstall();
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);
         }
-    }
 
+        if (!result) {
+            throw new MojoExecutionException("Installing failed");
+        }
+    }
 }

--- a/src/main/java/com/gluonhq/NativePackageMojo.java
+++ b/src/main/java/com/gluonhq/NativePackageMojo.java
@@ -42,13 +42,17 @@ public class NativePackageMojo extends NativeBaseMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        boolean result = true;
         try {
             SubstrateDispatcher dispatcher = createSubstrateDispatcher();
-            dispatcher.nativePackage();
+            result = dispatcher.nativePackage();
         } catch (Exception e) {
             e.printStackTrace();
             throw new MojoExecutionException("Error", e);
         }
-    }
 
+        if (!result) {
+            throw new MojoExecutionException("Packaging failed");
+        }
+    }
 }


### PR DESCRIPTION
Fail the package and install goals when the respective step fails in substrate.

Fixes #159 