### PR TITLE
Find and update next Substrate version from current version

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -18,18 +18,22 @@ tar xvf gpg_keys.tar
 # Release artifacts
 cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy -DskipTests=true -B -U -Prelease
 
-# Update version by 1
-newVersion=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
-
 # Update README with the latest released version
 sed -i "0,/<version>.*<\/version>/s//<version>$TRAVIS_TAG<\/version>/" README.md
 git commit README.md -m "Use latest release v$TRAVIS_TAG in README"
 
+# Update Substrate version
+SUBSTRATE_VERSION=$(mvn help:evaluate -Dexpression=substrate.version -q -DforceStdout)
+NEW_SUBSTRATE_VERSION=${SUBSTRATE_VERSION%.*}.$((${SUBSTRATE_VERSION##*.} + 1))
+
+# Update version by 1
+NEW_PROJECT_VERSION=${TRAVIS_TAG%.*}.$((${TRAVIS_TAG##*.} + 1))
+
 # Update project version to next snapshot version
-mvn versions:set -DnewVersion=$newVersion-SNAPSHOT -DgenerateBackupPoms=false
+mvn versions:set -DnewVersion=$NEW_PROJECT_VERSION-SNAPSHOT -DgenerateBackupPoms=false
 
 # Update Substrate to next snapshot version
-mvn versions:use-next-snapshots -Dincludes=com.gluonhq:substrate -DgenerateBackupPoms=false
+mvn versions:set-property -Dproperty=substrate.version -DnewVersion=$NEW_SUBSTRATE_VERSION-SNAPSHOT -DgenerateBackupPoms=false
 
 git commit pom.xml -m "Prepare development of $newVersion"
 git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$TRAVIS_REPO_SLUG HEAD:master

--- a/pom.xml
+++ b/pom.xml
@@ -46,13 +46,14 @@
     <maven.compiler.target>11</maven.compiler.target>
     <javadoc.plugin.version>3.1.0</javadoc.plugin.version>
     <gpg.plugin.version>1.6</gpg.plugin.version>
+    <substrate.version>0.0.24-SNAPSHOT</substrate.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.gluonhq</groupId>
       <artifactId>substrate</artifactId>
-      <version>0.0.24-SNAPSHOT</version>
+      <version>${substrate.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This PR updates Substrate version without relying on a snapshot release made of Maven Central.

It adds 1 to the current Substrate versions and appends SNAPSHOT to it.