### PR TITLE
Release Gluon Client docs

### DIFF
--- a/.ci/deploy-snapshot.sh
+++ b/.ci/deploy-snapshot.sh
@@ -9,3 +9,6 @@ then
     cp .travis.settings.xml $HOME/.m2/settings.xml
     mvn deploy -DskipTests=true
 fi
+
+# Update docs
+bash .ci/update-docs.sh "$ver"

--- a/.ci/deploy-snapshot.sh
+++ b/.ci/deploy-snapshot.sh
@@ -4,7 +4,7 @@
 ver=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 
 # deploy if snapshot found
-if [[ $ver == *"SNAPSHOT"* ]] 
+if [[ $ver == *"SNAPSHOT"* ]]
 then
     cp .travis.settings.xml $HOME/.m2/settings.xml
     mvn deploy -DskipTests=true

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -43,3 +43,6 @@ sh .ci/update-samples.sh "$TRAVIS_TAG"
 
 # Update archetypes
 bash .ci/update-archetypes.sh "$TRAVIS_TAG"
+
+# Update docs
+bash .ci/update-docs.sh "$TRAVIS_TAG"

--- a/.ci/update-docs.sh
+++ b/.ci/update-docs.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+DOCS_REPO_SLUG=gluonhq/docs
+
+cd $TRAVIS_BUILD_DIR
+git clone https://gluon-bot:$GITHUB_PASSWORD@github.com/$DOCS_REPO_SLUG
+cd docs
+
+# Update properties
+sed -i -z "0,/CLIENT_VERSION=.*/s//CLIENT_VERSION=$1/" gradle.properties
+
+# Create HTML docs
+./gradlew asciidoc
+
+# AWS copy
+pip install s3cmd
+s3cmd --no-mime-magic --guess-mime-type --access_key "$AWS_ACCESS_KEY" --secret_key "$AWS_SECRET_KEY" sync -P build/docs/html5/client/ s3://docs.gluonhq.com/client/$1/

--- a/.ci/update-docs.sh
+++ b/.ci/update-docs.sh
@@ -10,8 +10,9 @@ cd docs
 sed -i -z "0,/CLIENT_VERSION=.*/s//CLIENT_VERSION=$1/" gradle.properties
 
 # Create HTML docs
-./gradlew asciidoc
+sh gradlew asciidoc
 
 # AWS copy
 pip install s3cmd
+touch ~/.s3cfg
 s3cmd --no-mime-magic --guess-mime-type --access_key "$AWS_ACCESS_KEY" --secret_key "$AWS_SECRET_KEY" sync -P build/docs/html5/client/ s3://docs.gluonhq.com/client/$1/


### PR DESCRIPTION
This PR enables publishing of Client docs directly to S3 for both snapshot-releases and final-releases of client-maven-plugin.

P.S. The necessary environment variables have already been added to Travis