### PR TITLE
New client version should update docs repository

### DIFF
--- a/.ci/deploy-snapshot.sh
+++ b/.ci/deploy-snapshot.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Configure GIT
+git config --global user.name "Gluon Bot"
+git config --global user.email "githubbot@gluonhq.com"
+
 # Find version
 ver=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
 

--- a/.ci/update-docs.sh
+++ b/.ci/update-docs.sh
@@ -16,5 +16,5 @@ if [ $RESULT -eq 0 ]; then
   echo "There are no changes to commit"
 else
   git commit gradle.properties -am "Update client version to v$1"
-  git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$SAMPLES_REPO_SLUG HEAD:master
+  git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$DOCS_REPO_SLUG HEAD:master
 fi

--- a/.ci/update-docs.sh
+++ b/.ci/update-docs.sh
@@ -15,6 +15,13 @@ RESULT=$?
 if [ $RESULT -eq 0 ]; then
   echo "There are no changes to commit"
 else
-  git commit gradle.properties -am "Update client version to v$1"
+  git commit gradle.properties -m "Update client version to v$1"
+fi
+
+# Check for snapshot or release version
+if [[ $1 == *-SNAPSHOT ]]; then
   git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$DOCS_REPO_SLUG HEAD:master
+else
+  git tag "client-$1"
+  git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$DOCS_REPO_SLUG $1
 fi

--- a/.ci/update-docs.sh
+++ b/.ci/update-docs.sh
@@ -9,10 +9,12 @@ cd docs
 # Update properties
 sed -i -z "0,/CLIENT_VERSION=.*/s//CLIENT_VERSION=$1/" gradle.properties
 
-# Create HTML docs
-sh gradlew asciidoc
-
-# AWS copy
-pip install s3cmd
-touch ~/.s3cfg
-s3cmd --no-mime-magic --guess-mime-type --access_key "$AWS_ACCESS_KEY" --secret_key "$AWS_SECRET_KEY" sync -P build/docs/html5/client/ s3://docs.gluonhq.com/client/$1/
+# Commit only if there are changes
+git diff --quiet && git diff --staged --quiet
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+  echo "There are no changes to commit"
+else
+  git commit gradle.properties -am "Update client version to v$1"
+  git push https://gluon-bot:$GITHUB_PASSWORD@github.com/$SAMPLES_REPO_SLUG HEAD:master
+fi


### PR DESCRIPTION
We update the docs repository whenever a new snapshot or release version of the client-plugin is released. There is no change made if the snapshot is build for the same version twice.