### PR TITLE
Do not update docs on snapshot releases

### DIFF
--- a/.ci/deploy-snapshot.sh
+++ b/.ci/deploy-snapshot.sh
@@ -9,6 +9,3 @@ then
     cp .travis.settings.xml $HOME/.m2/settings.xml
     mvn deploy -DskipTests=true
 fi
-
-# Update docs
-bash .ci/update-docs.sh "$ver"


### PR DESCRIPTION
We do not want to update client version with SNAPSHOT. The properties file in docs should only be updated when releases are made.