### PR TITLE
Add release-drafter GA to create a Github Release draft

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+exclude-labels:
+  - 'housekeeping'
 template: |
   ## What’s Changed
   $CHANGES

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,16 @@
+name: Commit on master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft release
+        # Drafts your next Release notes as Pull Requests are merged into "master"
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automates release notes from PR. Each time a PR is merged into the master branch, it is added to the release notes in Github Release.

Example: https://github.com/abhinayagarwal/test-release-drafter/releases