### PR TITLE
Rename Client to GluonFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Gluon Client plugin for Maven
+# GluonFX plugin for Maven
 
-The Gluon Client plugin for maven projects leverages GraalVM, OpenJDK and JavaFX 11+, 
+GluonFX plugin for maven leverages GraalVM, OpenJDK and JavaFX 11+, 
 by compiling into native code the Java Client application and all its required dependencies, 
 so it can directly be executed as a native application on the target platform.
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.gluonhq/client-maven-plugin)](https://search.maven.org/search?q=g:com.gluonhq%20AND%20a:client-maven-plugin)
-[![Travis CI](https://api.travis-ci.org/gluonhq/client-maven-plugin.svg?branch=master)](https://travis-ci.org/gluonhq/client-maven-plugin)
+[![Github Actions](https://github.com/gluonhq/client-maven-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/gluonhq/client-maven-plugin/actions/workflows/build.yml)
 [![BSD-3 license](https://img.shields.io/badge/license-BSD--3-%230778B9.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 ## Requirements
@@ -22,7 +22,7 @@ Check the [documentation](https://docs.gluonhq.com/) for more details about the 
 
 ## Issues and Contributions ##
 
-Issues can be reported to the [Issue tracker](https://github.com/gluonhq/client-maven-plugin/issues)
+Issues can be reported to the [Issue tracker](https://github.com/gluonhq/gluonfx-maven-plugin/issues)
 
-Contributions can be submitted via [Pull requests](https://github.com/gluonhq/client-maven-plugin/pulls), 
-providing you have signed the [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY).
+Contributions can be submitted via [Pull requests](https://github.com/gluonhq/gluonfx-maven-plugin/pulls), 
+providing you have signed the [Gluon Individual Contributor License Agreement (CLA)](https://cla.gluonhq.com).

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
   <groupId>com.gluonhq</groupId>
   <artifactId>gluonfx-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
   <name>gluonfx-maven-plugin Maven Mojo</name>
-  <description>GluonFX plugin creates native images for JavaFX application</description>
+  <description>GluonFX plugin allows to run JavaFX application on the JVM or to create their native images.</description>
   <inceptionYear>2019</inceptionYear>
   <url>https://github.com/gluonhq/gluonfx-maven-plugin</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,13 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gluonhq</groupId>
-  <artifactId>client-maven-plugin</artifactId>
+  <artifactId>gluonfx-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.1.42-SNAPSHOT</version>
-  <name>client-maven-plugin Maven Mojo</name>
-  <description>The Gluon Client Plugin is used to run JavaFX 11+ projects with Graal</description>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>gluonfx-maven-plugin Maven Mojo</name>
+  <description>GluonFX plugin creates native images for JavaFX application</description>
   <inceptionYear>2019</inceptionYear>
-  <url>https://github.com/gluonhq/client-maven-plugin</url>
+  <url>https://github.com/gluonhq/gluonfx-maven-plugin</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -241,7 +241,7 @@
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/gluonhq/client-maven-plugin/issues</url>
+    <url>https://github.com/gluonhq/gluonfx-maven-plugin/issues</url>
   </issueManagement>
 
   <licenses>
@@ -268,9 +268,9 @@
   </developers>
 
   <scm>
-    <url>https://github.com/gluonhq/client-maven-plugin</url>
-    <connection>scm:git:git://github.com/gluonhq/client-maven-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com:gluonhq/client-maven-plugin.git</developerConnection>
+    <url>https://github.com/gluonhq/gluonfx-maven-plugin</url>
+    <connection>scm:git:git://github.com/gluonhq/gluonfx-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com:gluonhq/gluonfx-maven-plugin.git</developerConnection>
   </scm>
 
   <distributionManagement>

--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -79,52 +79,52 @@ public abstract class NativeBaseMojo extends AbstractMojo {
     @Parameter(readonly = true, required = true, defaultValue = "${basedir}")
     File basedir;
 
-    @Parameter(property = "client.graalvmHome")
+    @Parameter(property = "gluonfx.graalvmHome")
     String graalvmHome;
 
-    @Parameter(property = "client.javaStaticSdkVersion")
+    @Parameter(property = "gluonfx.javaStaticSdkVersion")
     String javaStaticSdkVersion;
 
-    @Parameter(property = "client.javafxStaticSdkVersion")
+    @Parameter(property = "gluonfx.javafxStaticSdkVersion")
     String javafxStaticSdkVersion;
 
-    @Parameter(property = "client.target", defaultValue = "host")
+    @Parameter(property = "gluonfx.target", defaultValue = "host")
     String target;
 
-    @Parameter(property = "client.bundlesList")
+    @Parameter(property = "gluonfx.bundlesList")
     List<String> bundlesList;
 
-    @Parameter(property = "client.resourcesList")
+    @Parameter(property = "gluonfx.resourcesList")
     List<String> resourcesList;
 
-    @Parameter(property = "client.reflectionList")
+    @Parameter(property = "gluonfx.reflectionList")
     List<String> reflectionList;
 
-    @Parameter(property = "client.jniList")
+    @Parameter(property = "gluonfx.jniList")
     List<String> jniList;
 
-    @Parameter(property = "client.nativeImageArgs")
+    @Parameter(property = "gluonfx.nativeImageArgs")
     List<String> nativeImageArgs;
 
-    @Parameter(readonly = true, required = true, defaultValue = "${project.build.directory}/client")
+    @Parameter(readonly = true, required = true, defaultValue = "${project.build.directory}/gluonfx")
     File outputDir;
 
-    @Parameter(property = "client.mainClass", required = true)
+    @Parameter(property = "gluonfx.mainClass", required = true)
     String mainClass;
 
-    @Parameter(property = "client.executable", defaultValue = "java")
+    @Parameter(property = "gluonfx.executable", defaultValue = "java")
     String executable;
 
-    @Parameter(property = "client.verbose", defaultValue = "false")
+    @Parameter(property = "gluonfx.verbose", defaultValue = "false")
     String verbose;
 
-    @Parameter(property = "client.attachList")
+    @Parameter(property = "gluonfx.attachList")
     List<String> attachList;
 
-    @Parameter(property = "client.enableSWRendering", defaultValue = "false")
+    @Parameter(property = "gluonfx.enableSWRendering", defaultValue = "false")
     String enableSWRendering;
 
-    @Parameter(property = "client.releaseConfiguration")
+    @Parameter(property = "gluonfx.releaseConfiguration")
     ReleaseConfiguration releaseConfiguration;
 
     private ProcessDestroyer processDestroyer;

--- a/src/main/java/com/gluonhq/NativeBaseMojo.java
+++ b/src/main/java/com/gluonhq/NativeBaseMojo.java
@@ -133,7 +133,7 @@ public abstract class NativeBaseMojo extends AbstractMojo {
         if (getGraalvmHome().isEmpty()) {
             throw new MojoExecutionException("GraalVM installation directory not found." +
                     " Either set GRAALVM_HOME as an environment variable or" +
-                    " set graalvmHome in client-plugin configuration");
+                    " set graalvmHome in gluonfx-plugin configuration");
         }
         ProjectConfiguration substrateConfiguration = createSubstrateConfiguration();
         return new SubstrateDispatcher(outputDir.toPath(), substrateConfiguration);

--- a/src/main/java/com/gluonhq/NativeBuildMojo.java
+++ b/src/main/java/com/gluonhq/NativeBuildMojo.java
@@ -72,14 +72,14 @@ public class NativeBuildMojo extends NativeBaseMojo {
 
         invocationRequest.setPomFile(new File(pom));
 
-        invocationRequest.setGoals(Arrays.asList("client:compile", "client:link"));
+        invocationRequest.setGoals(Arrays.asList("gluonfx:compile", "gluonfx:link"));
 
         final Invoker invoker = new DefaultInvoker();
         // execute:
         try {
             final InvocationResult invocationResult = invoker.execute(invocationRequest);
             if (invocationResult.getExitCode() != 0) {
-                throw new MojoExecutionException("Error, client:build failed", invocationResult.getExecutionException());
+                throw new MojoExecutionException("Error, gluonfx:build failed", invocationResult.getExecutionException());
             }
         } catch (MavenInvocationException e) {
             e.printStackTrace();


### PR DESCRIPTION
This PR renames the plugin to `gluonfx-maven-plugin` and bumps the current development version to `0.9.0`.